### PR TITLE
Infinite carousel

### DIFF
--- a/src/components/Slider/Slides.js
+++ b/src/components/Slider/Slides.js
@@ -24,6 +24,7 @@ const Slides = ( { sliderContents, mobile, }, ) => {
 	return (
 		<Carousel
 			autoplay
+			wrapAround
 			renderBottomCenterControls = { null }
 			slidesToShow = { mobile ? 1 : 3 }
 		>


### PR DESCRIPTION
Updating gatsby packages fixes the carousel issue. This makes the carousel infinitely wrap and will not fix the current carousel bug.